### PR TITLE
Fix BatchProviderROI incorrect super constructor invokation

### DIFF
--- a/BatchProviderROI.lua
+++ b/BatchProviderROI.lua
@@ -2,7 +2,7 @@ local BatchProviderROI, parent = torch.class('nnf.BatchProviderROI','nnf.BatchPr
 
 function BatchProviderROI:__init(dataset)
   local fp = {dataset=dataset}
-  parent:__init(fp)
+  parent.__init(self, fp)
   self.imgs_per_batch = 2
   self.scale = 600
   self.max_size = 1000


### PR DESCRIPTION
(1) so the  BatchProviderROI inherited fields can be properly saved by torch.save
(2) The following code produce correct output

```
require('nnf')
bp1 = nnf.BatchProviderROI({dataset="1"})
print(bp1.dataset) --prints 1
bp2 = nnf.BatchProviderROI({dataset="2"})
print(bp1.dataset) --prints 2 (should be 1)
```
